### PR TITLE
Fix symlinks in unzip for zip files.

### DIFF
--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -302,6 +302,9 @@ def unzip(conanfile, filename, destination=".", keep_permissions=False, pattern=
         def print_progress(_, __):
             pass
 
+    def is_symlink_zipinfo(zi):
+        return (zi.external_attr >> 28) == 0xA
+
     with zipfile.ZipFile(filename, "r") as z:
         zip_info = z.infolist()
         if pattern:
@@ -328,27 +331,34 @@ def unzip(conanfile, filename, destination=".", keep_permissions=False, pattern=
         extracted_size = 0
 
         print_progress.last_size = -1
-        if platform.system() == "Windows":
-            for file_ in zip_info:
-                extracted_size += file_.file_size
-                print_progress(extracted_size, uncompress_size)
-                try:
-                    z.extract(file_, full_path)
-                except Exception as e:
-                    output.error("Error extract %s\n%s" % (file_.filename, str(e)))
-        else:  # duplicated for, to avoid a platform check for each zipped file
-            for file_ in zip_info:
-                extracted_size += file_.file_size
-                print_progress(extracted_size, uncompress_size)
-                try:
+        keep_permissions = (keep_permissions and platform.system() == "Windows")
+        for file_ in zip_info:
+            extracted_size += file_.file_size
+            print_progress(extracted_size, uncompress_size)
+            try:
+                if not is_symlink_zipinfo(file_):
                     z.extract(file_, full_path)
                     if keep_permissions:
                         # Could be dangerous if the ZIP has been created in a non nix system
                         # https://bugs.python.org/issue15795
                         perm = file_.external_attr >> 16 & 0xFFF
                         os.chmod(os.path.join(full_path, file_.filename), perm)
-                except Exception as e:
-                    output.error("Error extract %s\n%s" % (file_.filename, str(e)))
+                else:
+                    # Read extracted file contents to find target path to link to
+                    z.extract(file_, full_path)
+                    full_name = os.path.join(full_path, file_.filename)
+                    target = load(conanfile, full_name)
+                    os.unlink(full_name)
+                    try:
+                        # Try create a link to target path
+                        os.symlink(target, full_name)
+                    except OSError:
+                        # If we failed to create a symlink, just copy the file.
+                        if not os.path.isabs(target):
+                            target = os.path.join(full_path, target)
+                        shutil.copy2(target, full_name)
+            except Exception as e:
+                output.error("Error extract %s\n%s" % (file_.filename, str(e)))
         output.writeln("")
 
 


### PR DESCRIPTION
zipfile does not support symlinks, so we must fixup symlinks during extraction.

Tested with cayman glibc/gcc .zip files containing symlinks.