### PR TITLE
Add support regex match for recipe reference

### DIFF
--- a/conans/model/recipe_ref.py
+++ b/conans/model/recipe_ref.py
@@ -175,7 +175,8 @@ class RecipeReference:
 
         condition = ((pattern == "&" and is_consumer) or
                       fnmatch.fnmatchcase(str(self), pattern) or
-                      fnmatch.fnmatchcase(self.repr_notime(), pattern))
+                      fnmatch.fnmatchcase(self.repr_notime(), pattern) or
+                      re.match(pattern, str(self)))
         if no_user_channel:
             condition = condition and not self.user and not self.channel
         if negate:


### PR DESCRIPTION
If there are multiple items in tool_requires of build profile, and any of them is required as tool in host context, that will lead to loop dependency in conan.

To avoid this loop, we should provide a way to prevent tool requires are injected to specific packages, like package which appear in the build profile. By default, tool requires in [tool_requires] of build profile are injected each package, like:
[tool_requires]
A/1
B/2
C/2

A/1 will requires tool B/2, C2, and B/2 will requires tool A/1 and C2, C/2 will requires A/1, B/2.

Conan provide fnpattern and negative patter so that we can filter package like: [tool_requires]
!A* : B/2
B/2 will not be injected as A/1's tool requires, but we need solution like: not A and not B and not C : A/1
not A and not B and not C : B/2
not A and not B and not C : C/2

This patch append re.match after the fnmatch, so that we can write the tool_requires like: [tool_requires]
!A|B|C : A/1
!A|B|C : B/2
!A|B|C : C/2