### PR TITLE
Add an EUC version number.

### DIFF
--- a/conan/cli/cli.py
+++ b/conan/cli/cli.py
@@ -17,6 +17,7 @@ from conan.cli.exit_codes import SUCCESS, ERROR_MIGRATION, ERROR_GENERAL, USER_C
     ERROR_SIGTERM, USER_CTRL_BREAK, ERROR_INVALID_CONFIGURATION, ERROR_UNEXPECTED
 from conan.internal.cache.home_paths import HomePaths
 from conans import __version__ as client_version
+from conans import __euc_version__ as euc_version
 from conan.errors import ConanException, ConanInvalidConfiguration, ConanMigrationError
 from conans.util.files import exception_message_safe
 
@@ -174,7 +175,7 @@ class Cli:
             command = self._commands[command_argument]
         except KeyError as exc:
             if command_argument in ["-v", "--version"]:
-                cli_out_write("Conan version %s" % client_version)
+                cli_out_write("Conan version %s-euc%s" % (client_version, euc_version))
                 return
 
             if command_argument in ["-h", "--help"]:

--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -3,3 +3,5 @@ REVISIONS = "revisions"  # Only when enabled in config, not by default look at s
 OAUTH_TOKEN = "oauth_token"
 
 __version__ = '2.0.17'
+
+__euc_version__ = '1'


### PR DESCRIPTION
As we may make breaking changes on top of the current conan version, it is helpful to have an EUC specific version number so we can check if users are using the latest conan or not.

Please increment this `__euc_version__` every time you make a change on the same conan `__version__` so that we can have unique version numbers to compare to.