### PR TITLE
Improve MSBuild to allow custom arguments.

### DIFF
--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -4,4 +4,4 @@ OAUTH_TOKEN = "oauth_token"
 
 __version__ = '2.0.17'
 
-__euc_version__ = '1'
+__euc_version__ = '2'

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -89,6 +89,7 @@ BUILT_IN_CONFS = {
     "tools.microsoft:winsdk_version": "Use this winsdk_version in vcvars",
     "tools.microsoft.msbuild:vs_version": "Defines the IDE version (15, 16, 17) when using the msvc compiler. Necessary if compiler.version specifies a toolset that is not the IDE default",
     "tools.microsoft.msbuild:max_cpu_count": "Argument for the /m when running msvc to build parallel projects",
+    "tools.microsoft.msbuild:flags": "List of extra flags to pass to msbuild",
     "tools.microsoft.msbuild:installation_path": "VS install path, to avoid auto-detect via vswhere, like C:/Program Files (x86)/Microsoft Visual Studio/2019/Community. Use empty string to disable",
     "tools.microsoft.msbuilddeps:exclude_code_analysis": "Suppress MSBuild code analysis for patterns",
     "tools.microsoft.msbuildtoolchain:compile_options": "Dictionary with MSBuild compiler options",


### PR DESCRIPTION
This is important for us to be able to specify paths from msvc_desktop to ensure MSBuild can find everything.

e.g. we need something like these flags for MSBuild to work succesfully:
```
self.conf_info.define("tools.microsoft.msbuild:flags", [
    "/p:VCTargetsPath=%s" % os.path.join(package_folder, "VS", "2022", "BuildTools", "Msbuild", "Microsoft", "VC", "v170", ""),
    "/p:WindowsTargetPlatformVersion=%s" % Sdk_version,
    "/p:PlatformToolset=v143",
    "/p:VCToolsInstallDir=%s" % os.path.join(VC_tools_dir, ""),
    "/ToolsVersion:Current",
])
```