### PR TITLE
Make meson support to build x86 with gcc on x86_64

### DIFF
--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -481,6 +481,8 @@ def _gcc_use_wrapper(conanfile):
 
         c_compiler = compiler_executables["c"]
         c_flags = conanfile.conf.get("tools.build:cflags", check_type=list)
+        if conanfile.settings_build.get_safe('arch') == 'x86_64' and conanfile.settings.get_safe("arch") == 'x86':
+            c_flags.append('-m32')
         c_sysroot_flags, c_remaining_flags = _take_sysroot_flags(c_flags)
         c_binutils_flags, c_remaining_flags = _take_binutils_flags(c_remaining_flags)
 


### PR DESCRIPTION
gcc uses same executable for building x86 and x86_64, so that we need a flag to tell compiler that we need to generate x86 binary explicitly.

We can also add lines in conanfile like:
```
        tc = MesonToolchain(self)
        tc.c_flags.append('-m32')
        tc.generate()
```
but that requires each package which uses meson to be updated.