### PR TITLE
Put the -m32 flag in the wrap_{c,cpp} {C,CPP}FLAGS for meson

### DIFF
--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -481,17 +481,17 @@ def _gcc_use_wrapper(conanfile):
 
         c_compiler = compiler_executables["c"]
         c_flags = conanfile.conf.get("tools.build:cflags", check_type=list)
-        if conanfile.settings_build.get_safe('arch') == 'x86_64' and conanfile.settings.get_safe("arch") == 'x86':
-            c_flags.append('-m32')
         c_sysroot_flags, c_remaining_flags = _take_sysroot_flags(c_flags)
         c_binutils_flags, c_remaining_flags = _take_binutils_flags(c_remaining_flags)
 
         cpp_compiler = compiler_executables["cpp"]
         cpp_flags = conanfile.conf.get("tools.build:cxxflags", check_type=list)
-        if conanfile.settings_build.get_safe('arch') == 'x86_64' and conanfile.settings.get_safe("arch") == 'x86':
-            cpp_flags.append('-m32')
         cpp_sysroot_flags, cpp_remaining_flags = _take_sysroot_flags(cpp_flags)
         cpp_binutils_flags, cpp_remaining_flags = _take_binutils_flags(cpp_remaining_flags)
+
+        if conanfile.settings_build.get_safe('arch') == 'x86_64' and conanfile.settings.get_safe("arch") == 'x86':
+            c_sysroot_flags.append('-m32')
+            cpp_sysroot_flags.append('-m32')
 
         if c_sysroot_flags or c_binutils_flags:
             wrap_c = os.path.abspath("wrap_gcc")


### PR DESCRIPTION
Otherwise it won't get picked up when using the wrapped compilers.

