### PR TITLE
Bump EUC version number.

### DIFF
--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -4,4 +4,4 @@ OAUTH_TOKEN = "oauth_token"
 
 __version__ = '2.0.17'
 
-__euc_version__ = '2'
+__euc_version__ = '3'


### PR DESCRIPTION
Now that we have fixed meson + pkgconfig and we have recipes which rely on this, we should probably bump the version number.