### PR TITLE
Instead of using separate EUC version number, use an extra digit.

### DIFF
--- a/conan/cli/cli.py
+++ b/conan/cli/cli.py
@@ -17,7 +17,6 @@ from conan.cli.exit_codes import SUCCESS, ERROR_MIGRATION, ERROR_GENERAL, USER_C
     ERROR_SIGTERM, USER_CTRL_BREAK, ERROR_INVALID_CONFIGURATION, ERROR_UNEXPECTED
 from conan.internal.cache.home_paths import HomePaths
 from conans import __version__ as client_version
-from conans import __euc_version__ as euc_version
 from conan.errors import ConanException, ConanInvalidConfiguration, ConanMigrationError
 from conans.util.files import exception_message_safe
 
@@ -175,7 +174,7 @@ class Cli:
             command = self._commands[command_argument]
         except KeyError as exc:
             if command_argument in ["-v", "--version"]:
-                cli_out_write("Conan version %s-euc%s" % (client_version, euc_version))
+                cli_out_write("Conan version %s" % client_version)
                 return
 
             if command_argument in ["-h", "--help"]:

--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -2,6 +2,4 @@ CHECKSUM_DEPLOY = "checksum_deploy"  # Only when v2
 REVISIONS = "revisions"  # Only when enabled in config, not by default look at server_launcher.py
 OAUTH_TOKEN = "oauth_token"
 
-__version__ = '2.0.17'
-
-__euc_version__ = '3'
+__version__ = '2.0.17.4'


### PR DESCRIPTION
The conan migration does not work properly unless the version number has changed per the rules in the conan Version class, so the update.py script in conan-recipes actually can break conan installations because conan does not realise it should recreate files that were lost during the update.py cleanup of profiles / extensions folders.

I have verified that conan's Version number comparison works with an extra digit, and that this fixes migration when using update.py script.