### PR TITLE
Fix PkgConfigCache to use generators folder instead of getcwd().

### DIFF
--- a/conan/tools/gnu/pkgconfigcache.py
+++ b/conan/tools/gnu/pkgconfigcache.py
@@ -25,7 +25,7 @@ class PkgConfigCache:
         cpp_info = CppInfo()
         pkg_config = PkgConfig(self._conanfile, path,
                                pkg_config_path=[
-                                  os.getcwd(), # To find PkgConfigDeps generated .pc files for our dependencies
+                                  self._conanfile.generators_folder, # To find PkgConfigDeps generated .pc files for our dependencies
                                   os.path.dirname(path), # To find any other .pc files from this package
                                ],
                                prefix=self._conan_prefix)

--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -2,4 +2,4 @@ CHECKSUM_DEPLOY = "checksum_deploy"  # Only when v2
 REVISIONS = "revisions"  # Only when enabled in config, not by default look at server_launcher.py
 OAUTH_TOKEN = "oauth_token"
 
-__version__ = '2.0.17.5'
+__version__ = '2.0.17.6'


### PR DESCRIPTION
Coincidentally these were the same for all the recipes I tested, but this seemingly is not always guaranteed.