### PR TITLE
Add gcc wrapper to autotools when using CC_FOR_BUILD.

### DIFF
--- a/conan/tools/build/wrapcc.py
+++ b/conan/tools/build/wrapcc.py
@@ -1,0 +1,60 @@
+import os
+import textwrap
+
+from conans.util.files import save
+from conan.tools.build import cmd_args_to_string
+
+def _chmod_plus_x(filename):
+    if os.name == "posix":
+        os.chmod(filename, os.stat(filename).st_mode | 0o111)
+
+
+def _take_sysroot_flags(flags):
+    sysroot_flags = [f for f in flags if f.startswith('--sysroot=')]
+    remaining_flags = [f for f in flags if f not in sysroot_flags]
+    return (sysroot_flags, remaining_flags)
+
+
+def _take_binutils_flags(flags):
+    indices = [i for i in range(len(flags)) if flags[i] == '-B']
+    binutil_flags = [flags[i] for i in range(len(flags)) if (i in indices or (i - 1) in indices)]
+    remaining_flags = [flags[i] for i in range(len(flags)) if (i not in indices and (i - 1) not in indices)]
+    return (binutil_flags, remaining_flags)
+
+
+def generate_wrapcc(conanfile, wrap_cc_filename, cc, cflags):
+    """
+    Generate a wrapper .sh to call compiler with --sysroot and -B flags inlined,
+    this is due to some build systems not passing sysroot when we need it to.
+
+    Returns: (path_to_wrap_cc, remaining_cflags)
+       path_to_wrap_cc may be None if a wrapper was not required
+    """
+
+    if conanfile.settings.compiler != "gcc":
+        # Currently only GCC is supported with wrapcc
+        return (None, cflags)
+
+    # Look for cflags --sysroot from glibc and -B from binutils
+    sysroot_flags, remaining_flags = _take_sysroot_flags(cflags)
+    binutils_flags, remaining_flags = _take_binutils_flags(remaining_flags)
+    arch_flags = []
+
+    # When cross-compiling for x86 from x86_64 we must specify -m32
+    if conanfile.settings_build.get_safe('arch') == 'x86_64' and conanfile.settings.get_safe("arch") == 'x86':
+        arch_flags.append('-m32')
+
+    wrap_flags = cmd_args_to_string(sysroot_flags + binutils_flags + arch_flags)
+    if not wrap_flags:
+        # If we have no flags, we do not need to generate a wrapper
+        return (None, cflags)
+
+    # Generate wrapper with flags inlined
+    wrap_cc = os.path.abspath(wrap_cc_filename)
+    save(wrap_cc, textwrap.dedent("""\
+        #!/usr/bin/env bash
+        exec %s %s $@
+    """ % (cc, wrap_flags)))
+    _chmod_plus_x(wrap_cc)
+
+    return (wrap_cc, remaining_flags)

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -12,6 +12,8 @@ from conan.tools.microsoft import VCVars, msvc_runtime_flag, unix_path
 from conan.tools.gnu.windres_wrapper import _generate_windres_wrapper
 from conan.errors import ConanException
 from conans.model.pkg_type import PackageType
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.build.wrapcc import generate_wrapcc
 
 
 class AutotoolsToolchain:
@@ -76,6 +78,12 @@ class AutotoolsToolchain:
 
         self.sysroot_flag = None
 
+        self.cc_for_build = None
+        self.cflags_for_build = []
+        self.cpp_for_build = None
+        self.cppflags_for_build = []
+        self.ldflags_for_build = []
+
         if cross_building(self._conanfile):
             os_host = conanfile.settings.get_safe("os")
             arch_host = conanfile.settings.get_safe("arch")
@@ -99,6 +107,25 @@ class AutotoolsToolchain:
                 # -isysroot makes all includes for your library relative to the build directory
                 self.apple_isysroot_flag = "-isysroot {}".format(sdk_path) if sdk_path else None
 
+            build_env = VirtualBuildEnv(self._conanfile, auto_generate=True).vars()
+            self.cc_for_build = build_env.get("CC_FOR_BUILD")
+            self.cflags_for_build = self._get_env_list(build_env.get("CFLAGS_FOR_BUILD", []))
+            if self.cc_for_build:
+                (wrap_cc_for_build, remaining_flags) = generate_wrapcc(conanfile, "wrap_cc_for_build", self.cc_for_build, self.cflags_for_build)
+                if wrap_cc_for_build:
+                    self.cc_for_build = wrap_cc_for_build
+                    self.cflags_for_build = remaining_flags
+
+            self.cpp_for_build = build_env.get("CPP_FOR_BUILD")
+            self.cppflags_for_build = self._get_env_list(build_env.get("CPPFLAGS_FOR_BUILD", []))
+            if self.cpp_for_build:
+                (wrap_cpp_for_build, remaining_flags) = generate_wrapcc(conanfile, "wrap_cpp_for_build", self.cpp_for_build, self.cppflags_for_build)
+                if wrap_cpp_for_build:
+                    self.cpp_for_build = wrap_cpp_for_build
+                    self.cppflags_for_build = remaining_flags
+
+            self.ldflags_for_build = self._get_env_list(build_env.get("LDFLAGS_FOR_BUILD", []))
+
         sysroot = self._conanfile.conf.get("tools.build:sysroot")
         sysroot = sysroot.replace("\\", "/") if sysroot is not None else None
         self.sysroot_flag = "--sysroot {}".format(sysroot) if sysroot else None
@@ -108,6 +135,11 @@ class AutotoolsToolchain:
                               self._get_triplets()
         self.autoreconf_args = self._default_autoreconf_flags()
         self.make_args = []
+
+    @staticmethod
+    def _get_env_list(v):
+        # FIXME: Should Environment have the "check_type=None" keyword as Conf?
+        return v.strip().split() if not isinstance(v, list) else v
 
     def _get_msvc_runtime_flag(self):
         flag = msvc_runtime_flag(self._conanfile)
@@ -177,6 +209,17 @@ class AutotoolsToolchain:
         if self._windres_rc:
             env.define_path("RC", unix_path(self._conanfile, self._windres_rc))
             env.define_path("WINDRES", unix_path(self._conanfile, self._windres_rc))
+
+        if self.cc_for_build:
+            env.define("CC_FOR_BUILD", self.cc_for_build)
+            env.define("CFLAGS_FOR_BUILD", self.cflags_for_build)
+
+        if self.cpp_for_build:
+            env.define("CPP_FOR_BUILD", self.cpp_for_build)
+            env.define("CPPFLAGS_FOR_BUILD", self.cppflags_for_build)
+
+        if self.ldflags_for_build:
+            env.define("LDFLAGS_FOR_BUILD", self.ldflags_for_build)
 
         return env
 

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -13,6 +13,7 @@ from conan.tools.env import VirtualBuildEnv
 from conan.tools.meson.helpers import *
 from conan.tools.microsoft import VCVars, msvc_runtime_flag
 from conans.util.files import save
+from conan.tools.build.wrapcc import generate_wrapcc
 
 
 class MesonToolchain(object):
@@ -457,62 +458,24 @@ class MesonToolchain(object):
         VCVars(self._conanfile).generate()
 
 
-def _chmod_plus_x(filename):
-    if os.name == "posix":
-        os.chmod(filename, os.stat(filename).st_mode | 0o111)
-
-
-def _take_sysroot_flags(flags):
-    sysroot_flags = [f for f in flags if f.startswith('--sysroot=')]
-    remaining_flags = [f for f in flags if f not in sysroot_flags]
-    return (sysroot_flags, remaining_flags)
-
-
-def _take_binutils_flags(flags):
-    indices = [i for i in range(len(flags)) if flags[i] == '-B']
-    binutil_flags = [flags[i] for i in range(len(flags)) if (i in indices or (i - 1) in indices)]
-    remaining_flags = [flags[i] for i in range(len(flags)) if (i not in indices and (i - 1) not in indices)]
-    return (binutil_flags, remaining_flags)
-
-
 def _gcc_use_wrapper(conanfile):
     if conanfile.settings.compiler == "gcc":
         compiler_executables = conanfile.conf.get("tools.build:compiler_executables", check_type=dict)
 
-        c_compiler = compiler_executables["c"]
+        cc = compiler_executables["c"]
         c_flags = conanfile.conf.get("tools.build:cflags", check_type=list)
-        c_sysroot_flags, c_remaining_flags = _take_sysroot_flags(c_flags)
-        c_binutils_flags, c_remaining_flags = _take_binutils_flags(c_remaining_flags)
-
-        cpp_compiler = compiler_executables["cpp"]
-        cpp_flags = conanfile.conf.get("tools.build:cxxflags", check_type=list)
-        cpp_sysroot_flags, cpp_remaining_flags = _take_sysroot_flags(cpp_flags)
-        cpp_binutils_flags, cpp_remaining_flags = _take_binutils_flags(cpp_remaining_flags)
-
-        if conanfile.settings_build.get_safe('arch') == 'x86_64' and conanfile.settings.get_safe("arch") == 'x86':
-            c_sysroot_flags.append('-m32')
-            cpp_sysroot_flags.append('-m32')
-
-        if c_sysroot_flags or c_binutils_flags:
-            wrap_c = os.path.abspath("wrap_gcc")
-            save(wrap_c, textwrap.dedent("""\
-                #!/usr/bin/env bash
-                exec %s %s %s $@
-            """ % (c_compiler, ' '.join(c_sysroot_flags), ' '.join(c_binutils_flags))))
-            _chmod_plus_x(wrap_c)
+        (wrap_cc, c_remaining_flags) = generate_wrapcc(conanfile, "wrap_cc", cc, c_flags)
+        if wrap_cc:
+            conanfile.conf.update("tools.build:compiler_executables", {
+                "c": wrap_cc,
+            })
             conanfile.conf.define("tools.build:cflags", c_remaining_flags)
-            conanfile.conf.update("tools.build:compiler_executables", {
-                "c": wrap_c,
-            })
 
-        if cpp_sysroot_flags or cpp_binutils_flags:
-            wrap_cpp = os.path.abspath("wrap_g++")
-            save(wrap_cpp, textwrap.dedent("""\
-                #!/usr/bin/env bash
-                exec %s %s %s $@
-            """ % (cpp_compiler, ' '.join(cpp_sysroot_flags), ' '.join(cpp_binutils_flags))))
-            _chmod_plus_x(wrap_cpp)
-            conanfile.conf.define("tools.build:cxxflags", cpp_remaining_flags)
+        cxx = compiler_executables["cpp"]
+        cxx_flags = conanfile.conf.get("tools.build:cxxflags", check_type=list)
+        (wrap_cxx, cxx_remaining_flags) = generate_wrapcc(conanfile, "wrap_cxx", cxx, cxx_flags)
+        if wrap_cxx:
             conanfile.conf.update("tools.build:compiler_executables", {
-                "cpp": wrap_cpp,
+                "cpp": wrap_cxx,
             })
+            conanfile.conf.define("tools.build:cxxflags", cxx_remaining_flags)

--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -2,4 +2,4 @@ CHECKSUM_DEPLOY = "checksum_deploy"  # Only when v2
 REVISIONS = "revisions"  # Only when enabled in config, not by default look at server_launcher.py
 OAUTH_TOKEN = "oauth_token"
 
-__version__ = '2.0.17.6'
+__version__ = '2.0.17.7'


### PR DESCRIPTION
Autotools will not pass cflags to the CC_FOR_BUILD compiler when testing if it works, so our --sysroot does not make it through. Instead we can use the same approach we used to workaround the same issue in meson - generate a .sh file with the value of --sysroot and -B inlined inside it.