### PR TITLE
support arm64ec in meson

### DIFF
--- a/conan/tools/meson/helpers.py
+++ b/conan/tools/meson/helpers.py
@@ -35,6 +35,7 @@ _meson_cpu_family_map = {
     'armv8': ('aarch64', 'armv8', 'little'),
     'armv8_32': ('aarch64', 'armv8_32', 'little'),
     'armv8.3': ('aarch64', 'armv8.3', 'little'),
+    'arm64ec': ('aarch64', 'arm64ec', 'little'),
     'avr': ('avr', 'avr', 'little'),
     'mips': ('mips', 'mips', 'big'),
     'mips64': ('mips64', 'mips64', 'big'),

--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -271,7 +271,8 @@ def _vcvars_arch(conanfile):
         arch = {'x86': 'arm64_x86',
                 'x86_64': 'arm64_x64',
                 'armv7': 'arm64_arm',
-                'armv8': 'arm64'}.get(arch_host)
+                'armv8': 'amd64_arm64',
+                'arm64ec':'amd64_arm64'}.get(arch_host)
 
     if not arch:
         raise ConanException('vcvars unsupported architectures %s-%s' % (arch_build, arch_host))


### PR DESCRIPTION
Changelog: Update _meson_cpu_family_map to support arm64ec

and the PR to fix: https://github.com/conan-io/conan/pull/15812#event-12085148579

- [X] https://github.com/conan-io/conan/issues/15809
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [X] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
