### PR TITLE
Prevent any pkgconfig package_folder paths escaping through.

### DIFF
--- a/conan/tools/gnu/pkgconfigcache.py
+++ b/conan/tools/gnu/pkgconfigcache.py
@@ -71,7 +71,9 @@ class PkgConfigCache:
     def install(self):
         cache_file_path = self._cache_file_path
         mkdir(self, os.path.dirname(cache_file_path))
-        save(self, cache_file_path, yaml.dump(self._components))
+        yaml_data = yaml.dump(self._components)
+        yaml_data = yaml_data.replace(self._conanfile.package_folder, self._conan_prefix)
+        save(self, cache_file_path, yaml_data)
 
     def load(self):
         yaml_data = load(self._conanfile, self._cache_file_path)

--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -2,4 +2,4 @@ CHECKSUM_DEPLOY = "checksum_deploy"  # Only when v2
 REVISIONS = "revisions"  # Only when enabled in config, not by default look at server_launcher.py
 OAUTH_TOKEN = "oauth_token"
 
-__version__ = '2.0.17.7'
+__version__ = '2.0.17.8'


### PR DESCRIPTION
It seems that some package folder paths were still making it through, so we can be more aggressive and do a string replace of any path that did survive the previous prefix based transformation attempts.