### PR TITLE
Add config option to allow exclusion of packages from source download.

### DIFF
--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -2,4 +2,4 @@ CHECKSUM_DEPLOY = "checksum_deploy"  # Only when v2
 REVISIONS = "revisions"  # Only when enabled in config, not by default look at server_launcher.py
 OAUTH_TOKEN = "oauth_token"
 
-__version__ = '2.0.17.8'
+__version__ = '2.0.17.9'

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -1,3 +1,4 @@
+import fnmatch
 import os
 import shutil
 from multiprocessing.pool import ThreadPool
@@ -185,6 +186,12 @@ class BinaryInstaller:
         conanfile = node.conanfile
         if node.binary == BINARY_EDITABLE:
             return
+
+        if download_source:
+            download_source_exclude = conanfile.conf.get("tools.build:download_source_exclude", check_type=str)
+            patterns = download_source_exclude.split("|")
+            if any(fnmatch.fnmatch(conanfile.name, pattern) for pattern in patterns):
+                return
 
         recipe_layout = self._cache.recipe_layout(node.ref)
         export_source_folder = recipe_layout.export_sources()

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -55,6 +55,7 @@ BUILT_IN_CONFS = {
     "tools.android:cmake_legacy_toolchain": "Define to explicitly pass ANDROID_USE_LEGACY_TOOLCHAIN_FILE in CMake toolchain",
     "tools.build:skip_test": "Do not execute CMake.test() and Meson.test() when enabled",
     "tools.build:download_source": "Force download of sources for every package",
+    "tools.build:download_source_exclude": "Exclude download of sources for packages matching this string of patterns separated by |",
     "tools.build:jobs": "Default compile jobs number -jX Ninja, Make, /MP VS (default: max CPUs)",
     "tools.build:sysroot": "Pass the --sysroot=<tools.build:sysroot> flag if available. (None by default)",
     "tools.build.cross_building:can_run": "Bool value that indicates whether is possible to run a non-native "


### PR DESCRIPTION
This is to help with conan -> fossa-deps generation where we use conan graph info with tools.build.download_source. We want to exclude cef from the source download because just the source is 60gb!