### PR TITLE
[MesonToolchain] Added `native` mechanism when cross-building (#15919)

### DIFF
--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -1,7 +1,7 @@
 import os
 import textwrap
 
-from jinja2 import Template
+from jinja2 import Template, StrictUndefined
 
 from conan.errors import ConanException
 from conan.internal import check_duplicated_generator
@@ -21,11 +21,10 @@ class MesonToolchain(object):
     """
     MesonToolchain generator
     """
-
     native_filename = "conan_meson_native.ini"
     cross_filename = "conan_meson_cross.ini"
 
-    _meson_file_template = textwrap.dedent("""
+    _meson_file_template = textwrap.dedent("""\
     [properties]
     {% for it, value in properties.items() -%}
     {{it}} = {{value}}
@@ -41,33 +40,76 @@ class MesonToolchain(object):
     {% endfor %}
 
     [binaries]
-    {% if c %}c = {{c}}{% endif %}
-    {% if cpp %}cpp = {{cpp}}{% endif %}
-    {% if ld %}ld = {{ld}}{% endif %}
-    {% if is_apple_system %}
-    {% if objc %}objc = '{{objc}}'{% endif %}
-    {% if objcpp %}objcpp = '{{objcpp}}'{% endif %}
+    {% if c %}
+    c = {{c}}
     {% endif %}
-    {% if c_ld %}c_ld = '{{c_ld}}'{% endif %}
-    {% if cpp_ld %}cpp_ld = '{{cpp_ld}}'{% endif %}
-    {% if ar %}ar = '{{ar}}'{% endif %}
-    {% if strip %}strip = '{{strip}}'{% endif %}
-    {% if as %}as = '{{as}}'{% endif %}
-    {% if windres %}windres = '{{windres}}'{% endif %}
-    {% if pkgconfig %}pkgconfig = '{{pkgconfig}}'{% endif %}
-    {% if pkgconfig %}pkg-config = '{{pkgconfig}}'{% endif %}
+    {% if cpp %}
+    cpp = {{cpp}}
+    {% endif %}
+    {% if ld %}
+    ld = {{ld}}
+    {% endif %}
+    {% if is_apple_system %}
+    {% if objc %}
+    objc = '{{objc}}'
+    {% endif %}
+    {% if objcpp %}
+    objcpp = '{{objcpp}}'
+    {% endif %}
+    {% endif %}
+    {% if c_ld %}
+    c_ld = '{{c_ld}}'
+    {% endif %}
+    {% if cpp_ld %}
+    cpp_ld = '{{cpp_ld}}'
+    {% endif %}
+    {% if ar %}
+    ar = '{{ar}}'
+    {% endif %}
+    {% if strip %}
+    strip = '{{strip}}'
+    {% endif %}
+    {% if as %}
+    as = '{{as}}'
+    {% endif %}
+    {% if windres %}
+    windres = '{{windres}}'
+    {% endif %}
+    {% if pkgconfig %}
+    pkgconfig = '{{pkgconfig}}'
+    {% endif %}
+    {% if pkgconfig %}
+    pkg-config = '{{pkgconfig}}'
+    {% endif %}
 
     [built-in options]
-    {% if buildtype %}buildtype = '{{buildtype}}'{% endif %}
-    {% if debug %}debug = {{debug}}{% endif %}
-    {% if default_library %}default_library = '{{default_library}}'{% endif %}
-    {% if b_vscrt %}b_vscrt = '{{b_vscrt}}' {% endif %}
-    {% if b_ndebug %}b_ndebug = {{b_ndebug}}{% endif %}
-    {% if b_staticpic %}b_staticpic = {{b_staticpic}}{% endif %}
-    {% if cpp_std %}cpp_std = '{{cpp_std}}' {% endif %}
-    {% if backend %}backend = '{{backend}}' {% endif %}
-    {% if pkg_config_path %}pkg_config_path = '{{pkg_config_path}}'{% endif %}
-    {% if build_pkg_config_path %}build.pkg_config_path = '{{build_pkg_config_path}}'{% endif %}
+    {% if buildtype %}
+    buildtype = '{{buildtype}}'
+    {% endif %}
+    {% if default_library %}
+    default_library = '{{default_library}}'
+    {% endif %}
+    {% if b_vscrt %}
+    b_vscrt = '{{b_vscrt}}'
+    {% endif %}
+    {% if b_ndebug %}
+    b_ndebug = {{b_ndebug}}
+    {% endif %}
+    {% if b_staticpic %}
+    b_staticpic = {{b_staticpic}}
+    {% endif %}
+    {% if cpp_std %}
+    cpp_std = '{{cpp_std}}'
+    {% endif %}
+    {% if backend %}
+    backend = '{{backend}}'
+    {% endif %}
+    {% if pkg_config_path %}
+    pkg_config_path = '{{pkg_config_path}}'
+    {% endif %}
+    {% if build_pkg_config_path %}
+    build.pkg_config_path = '{{build_pkg_config_path}}'
+    {% endif %}
     # C/C++ arguments
     c_args = {{c_args}} + preprocessor_definitions
     c_link_args = {{c_link_args}}
@@ -90,7 +132,7 @@ class MesonToolchain(object):
     {% endfor %}
     """)
 
-    def __init__(self, conanfile, backend=None):
+    def __init__(self, conanfile, backend=None, native=False):
         """
         :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
         :param backend: ``str`` ``backend`` Meson variable value. By default, ``ninja``.
@@ -99,9 +141,13 @@ class MesonToolchain(object):
         _gcc_use_wrapper(conanfile)
 
         self._conanfile = conanfile
-        self._os = self._conanfile.settings.get_safe("os")
+        self._native = native
         self._is_apple_system = is_apple_os(self._conanfile)
-
+        is_cross_building = cross_building(conanfile, skip_x64_x86=True)
+        if not is_cross_building and native:
+            raise ConanException("You can only pass native=True if you're cross-building, "
+                                 "otherwise, it could cause unexpected results.")
+        self._conanfile_conf = self._conanfile.conf_build if native else self._conanfile.conf
         # Values are kept as Python built-ins so users can modify them more easily, and they are
         # only converted to Meson file syntax for rendering
         # priority: first user conf, then recipe, last one is default "ninja"
@@ -156,12 +202,11 @@ class MesonToolchain(object):
         # Issue: https://github.com/conan-io/conan/issues/14935
         self.build_pkg_config_path = None
         self.libcxx, self.gcc_cxx11_abi = libcxx_flags(self._conanfile)
-
         #: Dict-like object with the build, host, and target as the Meson machine context
         self.cross_build = {}
         default_comp = ""
         default_comp_cpp = ""
-        if cross_building(conanfile, skip_x64_x86=True):
+        if native is False and is_cross_building:
             os_host = conanfile.settings.get_safe("os")
             arch_host = conanfile.settings.get_safe("arch")
             os_build = conanfile.settings_build.get_safe('os')
@@ -190,10 +235,11 @@ class MesonToolchain(object):
             default_comp_cpp = "cl"
 
         # Read configuration for compilers
-        compilers_by_conf = self._conanfile.conf.get("tools.build:compiler_executables", default={},
+        compilers_by_conf = self._conanfile_conf.get("tools.build:compiler_executables", default={},
                                                      check_type=dict)
         # Read the VirtualBuildEnv to update the variables
-        build_env = VirtualBuildEnv(self._conanfile, auto_generate=True).vars()
+        build_env = self._conanfile.buildenv_build.vars(self._conanfile) if native else (
+            VirtualBuildEnv(self._conanfile, auto_generate=True).vars())
         #: Sets the Meson ``c`` variable, defaulting to the ``CC`` build environment value.
         #: If provided as a blank-separated string, it will be transformed into a list.
         #: Otherwise, it remains a single string.
@@ -225,7 +271,7 @@ class MesonToolchain(object):
         self.windres = build_env.get("WINDRES")
         #: Defines the Meson ``pkgconfig`` variable. Defaulted to ``PKG_CONFIG``
         #: build environment value
-        self.pkgconfig = (self._conanfile.conf.get("tools.gnu:pkg_config", check_type=str) or
+        self.pkgconfig = (self._conanfile_conf.get("tools.gnu:pkg_config", check_type=str) or
                           build_env.get("PKG_CONFIG"))
         #: Defines the Meson ``c_args`` variable. Defaulted to ``CFLAGS`` build environment value
         self.c_args = self._get_env_list(build_env.get("CFLAGS", []))
@@ -259,7 +305,8 @@ class MesonToolchain(object):
         self.objcpp_link_args = []
 
         self._resolve_apple_flags_and_variables(build_env, compilers_by_conf)
-        self._resolve_android_cross_compilation()
+        if native is False:
+            self._resolve_android_cross_compilation()
 
     def _get_default_dirs(self):
         """
@@ -327,7 +374,7 @@ class MesonToolchain(object):
         if not self.cross_build or not self.cross_build["host"]["system"] == "android":
             return
 
-        ndk_path = self._conanfile.conf.get("tools.android:ndk_path")
+        ndk_path = self._conanfile_conf.get("tools.android:ndk_path")
         if not ndk_path:
             raise ConanException("You must provide a NDK path. Use 'tools.android:ndk_path' "
                                  "configuration field.")
@@ -348,11 +395,11 @@ class MesonToolchain(object):
 
     def _get_extra_flags(self):
         # Now, it's time to get all the flags defined by the user
-        cxxflags = self._conanfile.conf.get("tools.build:cxxflags", default=[], check_type=list)
-        cflags = self._conanfile.conf.get("tools.build:cflags", default=[], check_type=list)
-        sharedlinkflags = self._conanfile.conf.get("tools.build:sharedlinkflags", default=[], check_type=list)
-        exelinkflags = self._conanfile.conf.get("tools.build:exelinkflags", default=[], check_type=list)
-        linker_scripts = self._conanfile.conf.get("tools.build:linker_scripts", default=[], check_type=list)
+        cxxflags = self._conanfile_conf.get("tools.build:cxxflags", default=[], check_type=list)
+        cflags = self._conanfile_conf.get("tools.build:cflags", default=[], check_type=list)
+        sharedlinkflags = self._conanfile_conf.get("tools.build:sharedlinkflags", default=[], check_type=list)
+        exelinkflags = self._conanfile_conf.get("tools.build:exelinkflags", default=[], check_type=list)
+        linker_scripts = self._conanfile_conf.get("tools.build:linker_scripts", default=[], check_type=list)
         linker_script_flags = ['-T"' + linker_script + '"' for linker_script in linker_scripts]
         return {
             "cxxflags": cxxflags,
@@ -442,6 +489,15 @@ class MesonToolchain(object):
         }
 
     @property
+    def _filename(self):
+        if self.cross_build and self._native:
+            return self.native_filename
+        elif self.cross_build:
+            return self.cross_filename
+        else:
+            return self.native_filename
+
+    @property
     def _content(self):
         """
         Gets content of the file to be used by Meson as its context.
@@ -449,7 +505,8 @@ class MesonToolchain(object):
         :return: ``str`` whole Meson context content.
         """
         context = self._context()
-        content = Template(self._meson_file_template).render(context)
+        content = Template(self._meson_file_template, trim_blocks=True, lstrip_blocks=True,
+                           undefined=StrictUndefined).render(context)
         return content
 
     def generate(self):
@@ -459,8 +516,7 @@ class MesonToolchain(object):
         If Windows OS, it will be created a ``conanvcvars.bat`` as well.
         """
         check_duplicated_generator(self, self._conanfile)
-        filename = self.native_filename if not self.cross_build else self.cross_filename
-        save(filename, self._content)
+        save(self._filename, self._content)
         # FIXME: Should we check the OS and compiler to call VCVars?
         VCVars(self._conanfile).generate()
 
@@ -486,3 +542,24 @@ def _gcc_use_wrapper(conanfile):
                 "cpp": wrap_cxx,
             })
             conanfile.conf.define("tools.build:cxxflags", cxx_remaining_flags)
+
+        # Setup things for build
+        compiler_executables = {}
+        build_env = VirtualBuildEnv(conanfile, auto_generate=True).vars()
+        cc_for_build = build_env.get("CC_FOR_BUILD")
+        cflags_for_build = MesonToolchain._get_env_list(build_env.get("CFLAGS_FOR_BUILD", []))
+        if cc_for_build:
+            (wrap_cc_for_build, remaining_flags) = generate_wrapcc(conanfile, "wrap_cc_for_build", cc_for_build, cflags_for_build)
+            conanfile.conf_build.update("tools.build:compiler_executables", {
+                "c": wrap_cc_for_build,
+            })
+            conanfile.conf_build.define("tools.build:cxxflags", remaining_flags)
+
+        cxx_for_build = build_env.get("CPP_FOR_BUILD")
+        cxxflags_for_build = MesonToolchain._get_env_list(build_env.get("CPPFLAGS_FOR_BUILD", []))
+        if cxx_for_build:
+            (wrap_cxx_for_build, remaining_flags) = generate_wrapcc(conanfile, "wrap_cxx_for_build", cxx_for_build, cxxflags_for_build)
+            conanfile.conf_build.update("tools.build:compiler_executables", {
+                "cpp": wrap_cxx_for_build,
+            })
+            conanfile.conf_build.define("tools.build:cxxflags", remaining_flags)

--- a/conans/client/graph/profile_node_definer.py
+++ b/conans/client/graph/profile_node_definer.py
@@ -26,8 +26,13 @@ def initialize_conanfile_profile(conanfile, profile_build, profile_host, base_co
     settings_build = _per_package_settings(conanfile, profile_build, ref)
     if is_build_require or base_context == CONTEXT_BUILD:
         _initialize_conanfile(conanfile, profile_build, settings_build.copy(), ref)
+        conanfile.buildenv_build = None
+        conanfile.conf_build = None
     else:
         _initialize_conanfile(conanfile, profile_host, settings_host, ref)
+        # Host profile with some build profile information
+        conanfile.buildenv_build = profile_build.buildenv.get_profile_env(ref, conanfile._conan_is_consumer)
+        conanfile.conf_build = profile_build.conf.get_conanfile_conf(ref, conanfile._conan_is_consumer)
     conanfile.settings_build = settings_build
     conanfile.settings_target = None
 

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -9,7 +9,6 @@ from conans.model.conf import Conf
 from conans.model.dependencies import ConanFileDependencies
 from conans.model.layout import Folders, Infos, Layouts
 from conans.model.options import Options
-
 from conans.model.requires import Requirements
 from conans.model.settings import Settings
 

--- a/conans/test/functional/toolchains/meson/test_meson_native_attribute.py
+++ b/conans/test/functional/toolchains/meson/test_meson_native_attribute.py
@@ -1,0 +1,98 @@
+import os
+import platform
+import textwrap
+
+import pytest
+
+from conan.tools.apple.apple import _to_apple_arch, XCRun
+from conans.test.assets.sources import gen_function_cpp, gen_function_h
+from conans.test.utils.mocks import ConanFileMock
+from conans.test.utils.tools import TestClient
+from conans.util.runners import conan_run
+
+
+@pytest.mark.tool("meson")
+@pytest.mark.skipif(platform.system() != "Darwin", reason="requires OSX")
+def test_apple_meson_toolchain_cross_compiling():
+    arch_host = 'armv8' if platform.machine() == "x86_64" else "x86_64"
+    arch_build = 'armv8' if platform.machine() != "x86_64" else "x86_64"
+    profile = textwrap.dedent(f"""
+    [settings]
+    os = Macos
+    arch = {arch_host}
+    compiler = apple-clang
+    compiler.version = 13.0
+    compiler.libcxx = libc++
+    """)
+    profile_build = textwrap.dedent(f"""
+    [settings]
+    os = Macos
+    arch = {arch_build}
+    compiler = apple-clang
+    compiler.version = 13.0
+    compiler.libcxx = libc++
+    """)
+    conanfile_py = textwrap.dedent("""
+    from conan import ConanFile
+    from conan.tools.meson import Meson, MesonToolchain
+    from conan.tools.build import cross_building
+
+    class App(ConanFile):
+        settings = "os", "arch", "compiler", "build_type"
+        options = {"shared": [True, False], "fPIC": [True, False]}
+        default_options = {"shared": False, "fPIC": True}
+
+        def layout(self):
+            self.folders.build = "build"
+
+        def config_options(self):
+            if self.settings.os == "Windows":
+                self.options.rm_safe("fPIC")
+
+        def configure(self):
+            if self.options.shared:
+                self.options.rm_safe("fPIC")
+
+        def generate(self):
+            tc = MesonToolchain(self)
+            tc.generate()
+            # Forcing to create the native context too
+            if cross_building(self):
+                tc = MesonToolchain(self, native=True)
+                tc.generate()
+
+        def build(self):
+            meson = Meson(self)
+            meson.configure()
+            meson.build()
+    """)
+    meson_build = textwrap.dedent("""
+    project('tutorial', 'cpp')
+    hello = library('hello', 'hello.cpp')
+    # Even cross-building the library, we want to create an executable using only the native context
+    executable('mygen', 'mygen.cpp', native: true)
+    """)
+    my_gen_cpp = gen_function_cpp(name="main")
+    hello_h = gen_function_h(name="hello")
+    hello_cpp = gen_function_cpp(name="hello")
+    client = TestClient()
+    client.save({"conanfile.py": conanfile_py,
+                 "meson.build": meson_build,
+                 "hello.h": hello_h,
+                 "hello.cpp": hello_cpp,
+                 "mygen.cpp": my_gen_cpp,
+                 "profile_host": profile,
+                 "profile_build": profile_build})
+    client.run("build . --profile:build=profile_build --profile:host=profile_host")
+    libhello = os.path.join(client.current_folder, "build", "libhello.a")
+    assert os.path.isfile(libhello) is True
+    # Now, ensuring that we can run the mygen executable
+    mygen = os.path.join(client.current_folder, "build", "mygen")
+    client.run_command(f"'{mygen}'")
+    assert "Release!" in client.out
+    # Extra check for lib arch
+    conanfile = ConanFileMock({}, runner=conan_run)
+    xcrun = XCRun(conanfile)
+    lipo = xcrun.find('lipo')
+    client.run_command('"%s" -info "%s"' % (lipo, libhello))
+    assert "architecture: %s" % _to_apple_arch(arch_host) in client.out


### PR DESCRIPTION
* Added native attribute to MesonToolchain. Adapted the whole Meson mechanism

* Added functional test

* Added integration test

* Update conans/test/functional/toolchains/meson/test_meson_native_attribute.py

Co-authored-by: James <memsharded@gmail.com>

* typo

* Get back to cross_build check

* Fixed if-else condition if native

---------

Co-authored-by: James <memsharded@gmail.com>

Zhiyuan Wang: With modification to meson toolchain to use our compiler search method.