### PR TITLE
Provide requires_private in CppInfo

### DIFF
--- a/conan/tools/gnu/pkgconfigcache.py
+++ b/conan/tools/gnu/pkgconfigcache.py
@@ -28,8 +28,9 @@ class PkgConfigCache:
                                   self._conanfile.generators_folder, # To find PkgConfigDeps generated .pc files for our dependencies
                                   os.path.dirname(path), # To find any other .pc files from this package
                                ],
-                               prefix=self._conan_prefix)
-        pkg_config.fill_cpp_info(cpp_info)
+                               prefix=self._conan_prefix,
+                               no_recursive=True)
+        pkg_config.fill_cpp_info(cpp_info, is_system=False)
 
         filename = os.path.basename(path)[:-3]
         cpp_info.set_property("pkg_config_name",  filename)

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -35,11 +35,7 @@ class _PCContentGenerator:
         Requires: {{ requires|join(' ') }}
         {% endif %}
         {% if requires_private|length %}
-        {% if transitive_libs %}
-        Requires: {{ requires_private|join(' ') }}
-        {% else %}
         Requires.private: {{ requires_private|join(' ') }}
-        {% endif %}
         {% endif %}
     """)
 
@@ -114,13 +110,20 @@ class _PCContentGenerator:
 
     def _get_context(self, info):
         pc_variables = self._get_pc_variables(info.cpp_info)
+        requires = []
+        requires_private = []
+        if self._transitive_libs:
+            requires = info.requires + info.requires_private
+        else:
+            requires += info.requires
+            requires_private += info.requires_private
         context = {
             "name": info.name,
             "description": info.description,
             "version": self._dep.ref.version,
             "transitive_libs": self._transitive_libs,
-            "requires": info.requires,
-            "requires_private": info.requires_private,
+            "requires": requires,
+            "requires_private": requires_private,
             "pc_variables": pc_variables,
             "cflags": "",
             "libflags": ""

--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -101,8 +101,6 @@ class Node(object):
         assert not require.version_range  # No ranges slip into transitive_deps definitions
         # TODO: Might need to move to an update() for performance
         self.transitive_deps.pop(require, None)
-        # if "libx11/1.8.7" in str(self) and "libxdmcp/1.1.4" in str(require):
-        #     import pdb;pdb.set_trace()
         self.transitive_deps[require] = TransitiveRequirement(require, node)
 
         # Check if need to propagate downstream

--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -101,6 +101,8 @@ class Node(object):
         assert not require.version_range  # No ranges slip into transitive_deps definitions
         # TODO: Might need to move to an update() for performance
         self.transitive_deps.pop(require, None)
+        # if "libx11/1.8.7" in str(self) and "libxdmcp/1.1.4" in str(require):
+        #     import pdb;pdb.set_trace()
         self.transitive_deps[require] = TransitiveRequirement(require, node)
 
         # Check if need to propagate downstream

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -41,7 +41,6 @@ class DepsGraphBuilder(object):
         self._prepare_node(root_node, profile_host, profile_build, Options())
         self._initialize_requires(root_node, dep_graph, graph_lock, profile_build, profile_host)
         dep_graph.add_node(root_node)
-        zzl = None
         open_requires = deque((r, root_node) for r in root_node.conanfile.requires.values())
         try:
             while open_requires:
@@ -52,14 +51,10 @@ class DepsGraphBuilder(object):
                 new_node = self._expand_require(require, node, dep_graph, profile_host,
                                                 profile_build, graph_lock)
                 if new_node:
-                    if "libx11/1.8.7" in str(new_node):
-                        zzl = new_node
                     self._initialize_requires(new_node, dep_graph, graph_lock, profile_build,
                                               profile_host)
                     open_requires.extendleft((r, new_node)
                                              for r in reversed(new_node.conanfile.requires.values()))
-                    # if zzl and len(zzl.transitive_deps) > 14:
-                    #     import pdb;pdb.set_trace()
             self._remove_overrides(dep_graph)
             check_graph_provides(dep_graph)
         except GraphError as e:
@@ -198,8 +193,6 @@ class DepsGraphBuilder(object):
                 if not resolved:
                     self._resolve_alias(node, require, alias, graph)
             self._resolve_replace_requires(node, require, profile_build, profile_host, graph)
-            if "libx11/1.8.7" in str(node) and "libxdmcp/1.1.4" in str(require):
-                import pdb;pdb.set_trace()
             node.transitive_deps[require] = TransitiveRequirement(require, node=None)
 
     def _resolve_alias(self, node, require, alias, graph):

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -80,6 +80,7 @@ class _Component:
 
         self._sysroot = None
         self._requires = None
+        self._requires_private = None
 
         # LEGACY 1.X fields, can be removed in 2.X
         self.names = MockInfoProperty("cpp_info.names")
@@ -111,6 +112,7 @@ class _Component:
             "objects": self._objects,
             "sysroot": self._sysroot,
             "requires": self._requires,
+            "requires_private": self._requires_private,
             "properties": self._properties
         }
 
@@ -323,6 +325,16 @@ class _Component:
         self._requires = value
 
     @property
+    def requires_private(self):
+        if self._requires_private is None:
+            self._requires_private = []
+        return self._requires_private
+
+    @requires_private.setter
+    def requires_private(self, value):
+        self._requires_private = value
+
+    @property
     def required_component_names(self):
         """ Names of the required components of the same package (not scoped with ::)"""
         if self.requires is None:
@@ -370,6 +382,10 @@ class _Component:
         if other.requires:
             current_values = self.get_init("requires", [])
             merge_list(other.requires, current_values)
+
+        if other.requires_private:
+            current_values = self.get_init("requires_private", [])
+            merge_list(other.requires_private, current_values)
 
         if other._properties:
             current_values = self.get_init("_properties", {})

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -562,6 +562,7 @@ class CppInfo:
             return
         # Accumulate all external requires
         external = set(r.split("::")[0] for r in self._package.requires if "::" in r)
+        external.update(r.split("::")[0] for r in self._package.requires_private if "::" in r)
         internal = set(r for r in self._package.requires if "::" not in r)
         # TODO: Cache this, this is computed in different places
         for key, comp in self.components.items():


### PR DESCRIPTION

This pr includes several fixes for PkgConfig:
1. Current `PkgConfig.libs()` returns all the libs includes secondary dependency, which is not expected because it causes overlinking. I add `--maximum-traverse-depth` to limit it to direct dependency only.
2. The order of requires is very important for PkgConfig, because linker only search symbol after the library on Linux.
3. Introduce requires_private in PkgConfig and CppInfo, so that we don't lost the information in conan. In conan, the .pc file is generated with this way:
.pc files generated by open source project -> CppInfo -> .pc files generated by PkgConfigDeps
