### PR TITLE
provide system libs in pkgconfigcache

### DIFF
--- a/conan/tools/gnu/pkgconfig.py
+++ b/conan/tools/gnu/pkgconfig.py
@@ -27,7 +27,7 @@ class PkgConfig:
         executable = self._conanfile.conf.get("tools.gnu:pkg_config", default="pkg-config")
         command = [executable, '--' + option, self._library, '--print-errors']
         if self._no_recursive:
-            command += ["--maximum-traverse-depth=2"]
+            command += ["--maximum-traverse-depth=1"]
         if self._prefix:
             command += ["--define-variable=prefix=%s" % self._prefix]
         command = cmd_args_to_string(command)


### PR DESCRIPTION
Provide requires_private in CppInfo

`PkgConfig.fill_cpp_info` has an argument `system_libs`, but we cannot pass value from conan file. This patch add same argument in `PkgConfigCache.add_folder` and `PkgConfigCache.add_file` so that recipe conanfile can provide system_libs value.

For example, libdrm reports this error:
```
2024-07-10T00:58:46.5496852Z CMake Error at build/gcc-12-x86_64-20-release/generators/cmakedeps_macros.cmake:67 (message):
2024-07-10T00:58:46.5498023Z   Library 'm' not found in package.  If 'm' is a system library, declare it
2024-07-10T00:58:46.5498896Z   with 'cpp_info.system_libs' property
2024-07-10T00:58:46.5499400Z Call Stack (most recent call first):
2024-07-10T00:58:46.5500471Z   build/gcc-12-x86_64-20-release/generators/libdrm-Target-release.cmake:23 (conan_package_library_targets)
2024-07-10T00:58:46.5501752Z   build/gcc-12-x86_64-20-release/generators/libdrmTargets.cmake:24 (include)
2024-07-10T00:58:46.5502824Z   build/gcc-12-x86_64-20-release/generators/libdrm-config.cmake:16 (include)
2024-07-10T00:58:46.5503775Z   CMakeLists.txt:5 (find_package)
2024-07-10T00:58:46.5504099Z 
2024-07-10T00:58:46.5504110Z 
2024-07-10T00:58:46.5504369Z -- Configuring incomplete, errors occurred!
2024-07-10T00:58:46.5522541Z 
2024-07-10T00:58:46.5540030Z ERROR: libdrm/2.4.120 (test package): Error in build() method, line 20
2024-07-10T00:58:46.5540828Z 	cmake.configure()
2024-07-10T00:58:46.5541234Z 	ConanException: Error 1 while executing
```
the reason is `m` is treated as package instead of system libs, the generated libdrm.pc file is:
```
prefix=/
includedir=${prefix}/include
libdir=${prefix}/lib

Name: libdrm
Description: Userspace interface to kernel DRM services
Version: 2.4.120
Libs: -L${libdir} -ldrm -lm
Cflags: -I${includedir} -I${includedir}/libdrm
```

This patch also change maximum-traverse-depth from 2 to 1. There is a bug in `pkgconf` 1.8.0, which output nothing with `--maximum-traverse-depth=1`, so I have to set the value to 2 previously. But after investigation, conan use pkgconf 2.1.0 which has fix this bug, so it can output correct libs with  `--maximum-traverse-depth=1`.