### PR TITLE
Fix issue in check_component_requires

### DIFF
--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -567,6 +567,8 @@ class CppInfo:
         # TODO: Cache this, this is computed in different places
         for key, comp in self.components.items():
             external.update(r.split("::")[0] for r in comp.requires if "::" in r)
+            external.update(r.split("::")[0] for r in comp.requires_private if "::" in r)
+
             internal.update(r for r in comp.requires if "::" not in r)
 
         missing_internal = list(internal.difference(self.components))


### PR DESCRIPTION
Conan requires that all receips in `Requirements()` should be declared in CppInfo.requires. I add requires_private in CppInfo to match Requires.private in PkgConfig, but forgot to update `external` from component's requires_private.