### PR TITLE
fix issue in pkgconfigcache

### DIFF
--- a/conan/tools/gnu/pkgconfigcache.py
+++ b/conan/tools/gnu/pkgconfigcache.py
@@ -22,7 +22,10 @@ class PkgConfigCache:
         return os.path.join(self._conanfile.package_folder, "res", "pkg_config_cache.yml")
 
     def add_file(self, path, use_mod_version=False, system_libs=None):
-        cpp_info = CppInfo()
+        # This CppInfo will be filled into conanfile.cpp_info.components,
+        # so it should be created with set_defaults as True, same as
+        # conans.model.layout.Infos
+        cpp_info = CppInfo(set_defaults=True)
         pkg_config = PkgConfig(self._conanfile, path,
                                pkg_config_path=[
                                   self._conanfile.generators_folder, # To find PkgConfigDeps generated .pc files for our dependencies

--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -2,4 +2,4 @@ CHECKSUM_DEPLOY = "checksum_deploy"  # Only when v2
 REVISIONS = "revisions"  # Only when enabled in config, not by default look at server_launcher.py
 OAUTH_TOKEN = "oauth_token"
 
-__version__ = '2.2.3.9'
+__version__ = '2.2.3.10'


### PR DESCRIPTION
Fix 2 problems in PkgConfigCache and PkgConfig:
1. Extract framework from `linkflags` and add them to CppInfo.frameworks.
2. `CppInfo` should be created with `set_defaults=True`, same as `self.cpp_info.components` in conanfile's `package_info`.