### PR TITLE
Remove reset_tarinfo from zstd compression

### DIFF
--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -2,4 +2,4 @@ CHECKSUM_DEPLOY = "checksum_deploy"  # Only when v2
 REVISIONS = "revisions"  # Only when enabled in config, not by default look at server_launcher.py
 OAUTH_TOKEN = "oauth_token"
 
-__version__ = '2.2.3.10'
+__version__ = '2.2.3.11'

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -273,14 +273,6 @@ def compress_files(files, name, dest_dir, compressformat=None, compresslevel=Non
 
     if compressformat == "zstd":
         with open(tar_path, "wb") as tarfile_obj:
-            def reset_tarinfo(tarinfo):
-                """
-                Resets mtime in the tarinfo for consistency with
-                gzopen_without_timestamps()
-                """
-                tarinfo.mtime = 0
-                return tarinfo
-
             # Only provide level if it was overridden by config.
             zstd_kwargs = {}
             if compresslevel is not None:
@@ -295,7 +287,7 @@ def compress_files(files, name, dest_dir, compressformat=None, compresslevel=Non
                 with tarfile.open(mode="w|", fileobj=stream_writer,
                                   format=tarfile.PAX_FORMAT) as tar:
                     for filename, abs_path in sorted(files.items()):
-                        tar.add(abs_path, filename, recursive=False, filter=reset_tarinfo)
+                        tar.add(abs_path, filename, recursive=False)
     else:
         # FIXME, better write to disk sequentially and not keep tgz contents in memory
         with set_dirty_context_manager(tar_path), open(tar_path, "wb") as tgz_handle:


### PR DESCRIPTION
This is not actually equivalent of gzopen_without_timestamps, which was avoiding writing timestamps to the gzip stream which is different than removing timestamps from the files inside the tar archive.